### PR TITLE
corrected Args comments

### DIFF
--- a/src/Honeybee_Radiance Trans Material.py
+++ b/src/Honeybee_Radiance Trans Material.py
@@ -30,9 +30,9 @@ Provided by Honeybee 0.0.63
     
     Args:
         _materialName: Unique name for this material
-        _RTransmittance:
-        _GTransmittance:
-        _BTransmittance:
+        _RDiffReflectance: (black = min 0, white = max 1)
+        _GDiffReflectance: (black = min 0, white = max 1)
+        _BDiffReflectance: (black = min 0, white = max 1)
         _specularReflection: Reflected specularity; Matte = min 0, Uncoated Glass ~ .06, Satin = suggested max 0.07
         roughness: Surface roughness; Polished = 0, Low gloss = suggested max 0.02
         _diffuseTransmission: Diffuse Transmission; Opaque = 0, Transparent = 1


### PR DESCRIPTION
No changes to the code were made. This is purely a documentation error in the comments.

The documentation of the input data to the Honeybee_Radiance Trans Material.py was incorrect. 
The description of input data now matches the input data of the plugin and the Radiance convention. 